### PR TITLE
Use Path APIs for proper path construction and display

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -47,15 +47,11 @@ impl Report {
   /// Write a file to disk.
   pub fn persist(&self) -> Result<String, Error> {
     let uuid = Uuid::new_v4().hyphenated().to_string();
-    let tmp_dir = env::temp_dir();
-    let tmp_dir = match tmp_dir.to_str() {
-      Some(dir) => dir,
-      None => bail!("Could not create a tmp directory for a report."),
-    };
-    let file_path = format!("{}/report-{}.toml", tmp_dir, &uuid);
+    let mut file_path = env::temp_dir();
+    file_path.push(format!("report-{}.toml", &uuid));
     let mut file = File::create(&file_path)?;
     let toml = toml::to_string(&self)?;
     file.write_all(toml.as_bytes())?;
-    Ok(file_path)
+    Ok(format!("{}", file_path.display()))
   }
 }


### PR DESCRIPTION
**Choose one:** is this a 🐛 bug fix

Before this change I was shown a path like `/var/folders/6l/3b74wfrs185cycvzkgz46ymw0000gp/T//report-d522a1a5-de9e-4a67-bee7-7904fbb463d7.toml` (see the double-forward slash? It's not wrong, but still weird)

After this change I see the expected path with a single slash.

## Checklist
nothing applies

- [ ] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
-

## Semver Changes
patch


Addendum: Your `Cargo.lock` needs an update now that 0.2 is released.