### PR TITLE
Properly handle file paths using Path and PathBuf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use report::{Method, Report};
 
 use failure::Error as FailError;
 use std::io::{Result as IoResult, Write};
+use std::path::PathBuf;
 use std::panic::PanicInfo;
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
@@ -51,7 +52,7 @@ macro_rules! setup_panic {
 }
 
 /// Utility function that prints a message to our human users
-pub fn print_msg(file_path: String, meta: &Metadata) -> IoResult<()> {
+pub fn print_msg(file_path: PathBuf, meta: &Metadata) -> IoResult<()> {
   let (_version, name, authors, homepage) = (
     meta.version,
     meta.name,
@@ -65,7 +66,7 @@ pub fn print_msg(file_path: String, meta: &Metadata) -> IoResult<()> {
 
   writeln!(&mut buffer, "Well, this is embarrasing.\n")?;
   writeln!(&mut buffer, "{} had a problem and crashed. To help us diagnose the problem you can send us a crash report.\n", name)?;
-  writeln!(&mut buffer, "We have generated a report file at \"{}\". Submit an issue or email with the subject of \"{} Crash Report\" and include the report as an attachment.\n", &file_path, name)?;
+  writeln!(&mut buffer, "We have generated a report file at \"{}\". Submit an issue or email with the subject of \"{} Crash Report\" and include the report as an attachment.\n", file_path.display(), name)?;
 
   if !homepage.is_empty() {
     writeln!(&mut buffer, "- Homepage: {}", homepage)?;
@@ -81,7 +82,7 @@ pub fn print_msg(file_path: String, meta: &Metadata) -> IoResult<()> {
 }
 
 /// Utility function which will handle dumping information to disk
-pub fn handle_dump(panic_info: &PanicInfo) -> Result<String, FailError> {
+pub fn handle_dump(panic_info: &PanicInfo) -> Result<PathBuf, FailError> {
   let mut expl = String::new();
 
   let payload = panic_info.payload().downcast_ref::<&str>();

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,7 +7,7 @@ extern crate uuid;
 
 use self::failure::Error;
 use self::uuid::Uuid;
-use std::{env, fs::File, io::Write};
+use std::{env, fs::File, io::Write, path::Path, path::PathBuf};
 
 /// Method of failure.
 #[derive(Debug, Serialize)]
@@ -45,14 +45,15 @@ impl Report {
   }
 
   /// Write a file to disk.
-  pub fn persist(&self) -> Result<String, Error> {
+  pub fn persist(&self) -> Result<PathBuf, Error> {
     let uuid = Uuid::new_v4().hyphenated().to_string();
     let tmp_dir = env::temp_dir();
     let tmp_dir = match tmp_dir.to_str() {
       Some(dir) => dir,
       None => bail!("Could not create a tmp directory for a report."),
     };
-    let file_path = format!("{}/report-{}.toml", tmp_dir, &uuid);
+    let file_name = format!("report-{}.toml", &uuid);
+    let file_path = Path::new(tmp_dir).join(file_name);
     let mut file = File::create(&file_path)?;
     let toml = toml::to_string(&self)?;
     file.write_all(toml.as_bytes())?;


### PR DESCRIPTION
🐛 bug fix

During trying human-panic, the current path caught my eye: `/var/folders/zw/bpfvmq390lv2c6gn_6byyv0w0000gn/T//report-9f934660-cf8f-418c-be89-c99728664a46.toml`. There's a double "//" in there, which usually indicates that you are joining paths using `format!` instead of properly using the path API. This change makes human-panic use the path API.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

To the extend they passed before, `examples/err.rs` is broken.

## Semver Changes

path version bump, I consider this a bugfix.
