### PR TITLE
Fixing wrong data in certain crash dump fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,8 @@ pub fn print_msg<P: AsRef<Path>>(
   file_path: P,
   meta: &Metadata,
 ) -> IoResult<()> {
-  let (_version, name, authors, homepage) = (
-    meta.version,
-    meta.name,
-    meta.authors,
-    meta.homepage,
-  );
+  let (_version, name, authors, homepage) =
+    (meta.version, meta.name, meta.authors, meta.homepage);
 
   let stderr = BufferWriter::stderr(ColorChoice::Auto);
   let mut buffer = stderr.buffer();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@ use report::{Method, Report};
 
 use failure::Error as FailError;
 use std::io::{Result as IoResult, Write};
-use std::panic::PanicInfo;
 use std::path::{Path, PathBuf};
+use std::panic::PanicInfo;
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
 /// A convenient metadata struct that describes a crate
@@ -55,12 +55,8 @@ pub fn print_msg<P: AsRef<Path>>(
   file_path: P,
   meta: &Metadata,
 ) -> IoResult<()> {
-  let (_version, name, authors, homepage) = (
-    meta.version,
-    meta.name,
-    meta.authors,
-    meta.homepage,
-  );
+  let (_version, name, authors, homepage) =
+    (meta.version, meta.name, meta.authors, meta.homepage);
 
   let stderr = BufferWriter::stderr(ColorChoice::Auto);
   let mut buffer = stderr.buffer();
@@ -101,10 +97,7 @@ pub fn print_msg<P: AsRef<Path>>(
 }
 
 /// Utility function which will handle dumping information to disk
-pub fn handle_dump(
-  meta: &Metadata,
-  panic_info: &PanicInfo,
-) -> Result<PathBuf, FailError> {
+pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo) -> Result<PathBuf, FailError> {
   let mut expl = String::new();
 
   let payload = panic_info.payload().downcast_ref::<&str>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,6 @@ pub fn handle_dump(
     None => expl.push_str("Panic location uknown.\n"),
   }
 
-  let report = Report::new(meta.name, meta.version, Method::Panic, expl);
+  let report = Report::new(&meta.name, &meta.version, Method::Panic, expl);
   report.persist()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@ use report::{Method, Report};
 
 use failure::Error as FailError;
 use std::io::{Result as IoResult, Write};
-use std::path::{Path, PathBuf};
 use std::panic::PanicInfo;
+use std::path::{Path, PathBuf};
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
 /// A convenient metadata struct that describes a crate
@@ -55,8 +55,12 @@ pub fn print_msg<P: AsRef<Path>>(
   file_path: P,
   meta: &Metadata,
 ) -> IoResult<()> {
-  let (_version, name, authors, homepage) =
-    (meta.version, meta.name, meta.authors, meta.homepage);
+  let (_version, name, authors, homepage) = (
+    meta.version,
+    meta.name,
+    meta.authors,
+    meta.homepage,
+  );
 
   let stderr = BufferWriter::stderr(ColorChoice::Auto);
   let mut buffer = stderr.buffer();
@@ -97,7 +101,10 @@ pub fn print_msg<P: AsRef<Path>>(
 }
 
 /// Utility function which will handle dumping information to disk
-pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo) -> Result<PathBuf, FailError> {
+pub fn handle_dump(
+  meta: &Metadata,
+  panic_info: &PanicInfo,
+) -> Result<PathBuf, FailError> {
   let mut expl = String::new();
 
   let payload = panic_info.payload().downcast_ref::<&str>();

--- a/src/report.rs
+++ b/src/report.rs
@@ -10,7 +10,7 @@ use self::uuid::Uuid;
 use std::{env, fs::File, io::Write, path::Path, path::PathBuf};
 
 /// Method of failure.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub enum Method {
   Panic,
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -26,9 +26,9 @@ pub struct Report {
 
 impl Report {
   /// Create a new instance.
-  pub fn new<S: Into<String>>(
-    name: S,
-    version: S,
+  pub fn new(
+    name: &str,
+    version: &str,
     method: Method,
     explanation: String,
   ) -> Self {
@@ -40,8 +40,8 @@ impl Report {
     };
 
     Self {
-      crate_version: version.into(),
-      name: name.into(),
+      crate_version: version.to_string(),
+      name: name.to_string(),
       operating_system,
       method,
       explanation,

--- a/src/report.rs
+++ b/src/report.rs
@@ -26,7 +26,12 @@ pub struct Report {
 
 impl Report {
   /// Create a new instance.
-  pub fn new<S: Into<String>>(name: S, version: S, method: Method, explanation: String) -> Self {
+  pub fn new<S: Into<String>>(
+    name: S,
+    version: S,
+    method: Method,
+    explanation: String,
+  ) -> Self {
     let operating_system = if cfg!(windows) {
       "windows".to_string()
     } else {

--- a/src/report.rs
+++ b/src/report.rs
@@ -10,7 +10,7 @@ use self::uuid::Uuid;
 use std::{env, fs::File, io::Write, path::Path, path::PathBuf};
 
 /// Method of failure.
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, Copy)]
 pub enum Method {
   Panic,
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -26,7 +26,7 @@ pub struct Report {
 
 impl Report {
   /// Create a new instance.
-  pub fn new(method: Method, explanation: String) -> Self {
+  pub fn new<S: Into<String>>(name: S, version: S, method: Method, explanation: String) -> Self {
     let operating_system = if cfg!(windows) {
       "windows".to_string()
     } else {
@@ -35,8 +35,8 @@ impl Report {
     };
 
     Self {
-      crate_version: env!("CARGO_PKG_VERSION").to_string(),
-      name: env!("CARGO_PKG_NAME").to_string(),
+      crate_version: version.into(),
+      name: name.into(),
       operating_system,
       method,
       explanation,


### PR DESCRIPTION
This a 🐛 bug fix.

Currently this is what the crash dump looked for a tool I wanted to use `human-panic` in:

```
name = "human-panic"
operating_system = "unix:Unknown"
crate_version = "0.2.0"
explanation = "Panic occurred in file 'libcore/option.rs' at line 335\n"
method = "Panic"
```

This change (using the Metadata object we pass around anyways) fixes this problem