### PR TITLE
Only Metadata<'static> works, remove generic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,11 @@ use std::panic::PanicInfo;
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
 /// A convenient metadata struct that describes a crate
-pub struct Metadata<'a> {
-  pub version: &'a str,
-  pub name: &'a str,
-  pub authors: &'a str,
-  pub homepage: &'a str,
+pub struct Metadata {
+  pub version: &'static str,
+  pub name: &'static str,
+  pub authors: &'static str,
+  pub homepage: &'static str,
 }
 
 /// Setup the human panic hook that will make all panics


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** is this a 🐛 bug fix

`Metadata<'a>` is wrong, since only `a==static` will compile. This changes it for clarity.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests pass (still no tests)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context

N/A

## Semver Changes

Changed `Metadata` is technically `pub`, though users of this library are unlikely to provide their own.