### PR TITLE
Adding proper backtraces to the dump files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "human-panic"
 version = "0.2.0"
 dependencies = [
+ "backtrace 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_type 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ toml = "0.4.6"
 serde = "1.0.38"
 failure = "0.1.1"
 os_type = "2.0.0"
+backtrace = "0.3"
 
 [features]
 nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate failure;
 #[macro_use]
 extern crate serde_derive;
 extern crate termcolor;
+extern crate backtrace;
 
 mod report;
 use report::{Method, Report};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,12 @@
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 
+extern crate backtrace;
 #[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate serde_derive;
 extern crate termcolor;
-extern crate backtrace;
 
 mod report;
 use report::{Method, Report};

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,7 +7,7 @@ extern crate uuid;
 
 use self::failure::Error;
 use self::uuid::Uuid;
-use backtrace::{Backtrace, BacktraceSymbol};
+use backtrace::Backtrace;
 use std::{env, fs::File, io::Write, path::Path, path::PathBuf};
 
 /// Method of failure.

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,6 +7,7 @@ extern crate uuid;
 
 use self::failure::Error;
 use self::uuid::Uuid;
+use backtrace::{Backtrace, BacktraceSymbol};
 use std::{env, fs::File, io::Write, path::Path, path::PathBuf};
 
 /// Method of failure.
@@ -22,6 +23,7 @@ pub struct Report {
   crate_version: String,
   explanation: String,
   method: Method,
+  backtrace: String,
 }
 
 impl Report {
@@ -39,12 +41,15 @@ impl Report {
       format!("unix:{:?}", platform.os_type)
     };
 
+    let backtrace = format!("{:#?}", Backtrace::new());
+
     Self {
       crate_version: version.to_string(),
       name: name.to_string(),
       operating_system,
       method,
       explanation,
+      backtrace,
     }
   }
 
@@ -59,7 +64,7 @@ impl Report {
     let file_name = format!("report-{}.toml", &uuid);
     let file_path = Path::new(tmp_dir).join(file_name);
     let mut file = File::create(&file_path)?;
-    let toml = toml::to_string(&self)?;
+    let toml = toml::to_string_pretty(&self)?;
     file.write_all(toml.as_bytes())?;
     Ok(file_path)
   }


### PR DESCRIPTION
**Choose one:** is this a 🙋 feature

This PR adds a full backtrace of the application to the `dump.toml` files. This adds the `backtrace` dependency

## What is generated

```
spacekookie@azedes ~/P/human-panic> cat /tmp/report-fb71d719-7826-48d5-a0c2-376f6dd62725.toml                                                                                                                21:32:10
name = 'human-panic'
operating_system = 'unix:Unknown'
crate_version = '0.2.0'
explanation = '''
Cause: OMG EVERYTHING IS ON FIRE!!!. Panic occurred in file 'examples/panic.rs' at line 8
'''
method = 'Panic'
backtrace = '''
stack backtrace:
   0:     0x55968f4db994 - backtrace::backtrace::libunwind::trace::h69e50feca54bfb84
                        at /home/spacekookie/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.6/src/backtrace/libunwind.rs:53
                         - backtrace::backtrace::trace::h42967341e0b01ccc
                        at /home/spacekookie/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.6/src/backtrace/mod.rs:42
   1:     0x55968f4d7cec - backtrace::capture::Backtrace::new_unresolved::h36be24e76bfa4f31
                        at /home/spacekookie/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.6/src/capture.rs:88
   2:     0x55968f4d7c3e - backtrace::capture::Backtrace::new::hc832014ed61bd4e7
                        at /home/spacekookie/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.6/src/capture.rs:63
   3:     0x55968f33fba2 - human_panic::report::Report::new::ha539f22860624c87
                        at src/report.rs:44
   4:     0x55968f33f0b8 - human_panic::handle_dump::h4c68954e17156a9e
                        at src/lib.rs:125
   5:     0x55968f33eca3 - panic::main::{{closure}}::h16efb9f5db108f06
                        at /home/spacekookie/Personal/human-panic/<setup_panic macros>:9
   6:     0x55968f502e19 - std::panicking::rust_panic_with_hook::h67aa5b75b91b798b
                        at libstd/panicking.rs:401
   7:     0x55968f356963 - std::panicking::begin_panic::h15a1f1e6ae42e75d
                        at /checkout/src/libstd/panicking.rs:363
   8:     0x55968f33e3c8 - panic::main::hf7ea8360284344ee
                        at examples/panic.rs:8
   9:     0x55968f33ca91 - std::rt::lang_start::{{closure}}::h02d109a9db8c7d30
                        at /checkout/src/libstd/rt.rs:74
  10:     0x55968f502ad7 - std::rt::lang_start_internal::{{closure}}::h2e4baf0a27c956a3
                        at libstd/rt.rs:59
                         - std::panicking::try::do_call::h73f98ed0647c7274
                        at libstd/panicking.rs:305
  11:     0x55968f514cfe - __rust_maybe_catch_panic
                        at libpanic_unwind/lib.rs:101
  12:     0x55968f4fefd5 - std::panicking::try::h18fbb145180d4cd9
                        at libstd/panicking.rs:284
                         - std::panic::catch_unwind::hc4b6a212a30b4bc5
                        at libstd/panic.rs:361
                         - std::rt::lang_start_internal::h8b001b4244930d51
                        at libstd/rt.rs:58
  13:     0x55968f33ca71 - std::rt::lang_start::hb8e0e1d72243fe33
                        at /checkout/src/libstd/rt.rs:74
  14:     0x55968f33e3fd - main
  15:     0x7f8b79cd5f29 - __libc_start_main
  16:     0x55968f33bae9 - _start
  17:                0x0 - <unknown>'''
```

## Checklist
- [ ] tests pass

## Context
Mildly related to #15 

## Semver Changes
Bumping the minor is probably fine
