### PR TITLE
Fixing the formatting for authors from ':' to ', ' as a seperator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ macro_rules! setup_panic {
   () => {
     use human_panic::*;
     use std::panic::{self, PanicInfo};
-  
+
     let meta = Metadata {
       version: env!("CARGO_PKG_VERSION"),
       name: env!("CARGO_PKG_NAME"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,15 +18,15 @@ use std::path::{Path, PathBuf};
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
 /// A convenient metadata struct that describes a crate
-pub struct Metadata<'a> {
+pub struct Metadata {
   /// The crate version
-  pub version: &'a str,
+  pub version: &'static str,
   /// The crate name
-  pub name: &'a str,
+  pub name: &'static str,
   /// The list of authors of the crate
-  pub authors: &'a str,
+  pub authors: String,
   /// The URL of the crate's website
-  pub homepage: &'a str,
+  pub homepage: &'static str,
 }
 
 /// Setup the human panic hook that will make all panics
@@ -36,11 +36,11 @@ macro_rules! setup_panic {
   () => {
     use human_panic::*;
     use std::panic::{self, PanicInfo};
-
+  
     let meta = Metadata {
       version: env!("CARGO_PKG_VERSION"),
       name: env!("CARGO_PKG_NAME"),
-      authors: env!("CARGO_PKG_AUTHORS"),
+      authors: env!("CARGO_PKG_AUTHORS").replace(":", ", "),
       homepage: env!("CARGO_PKG_HOMEPAGE"),
     };
 
@@ -60,7 +60,7 @@ pub fn print_msg<P: AsRef<Path>>(
   meta: &Metadata,
 ) -> IoResult<()> {
   let (_version, name, authors, homepage) =
-    (meta.version, meta.name, meta.authors, meta.homepage);
+    (meta.version, meta.name, &meta.authors, meta.homepage);
 
   let stderr = BufferWriter::stderr(ColorChoice::Auto);
   let mut buffer = stderr.buffer();


### PR DESCRIPTION
**Choose one:** is this a 🐛 bug fix

There was a bug in the formatting of the authors list


## Checklist
- [x] tests pass


## Semver Changes
Bump patch