### PR TITLE
Fixing double panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ macro_rules! setup_panic {
     panic::set_hook(Box::new(move |info: &PanicInfo| {
       let file_path = handle_dump(&meta, info);
 
-      print_msg(&file_path, &meta)
+      print_msg(file_path, &meta)
         .expect("human-panic: printing error message to console failed");
     }));
   };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ extern crate termcolor;
 mod report;
 use report::{Method, Report};
 
-use failure::Error as FailError;
 use std::io::{Result as IoResult, Write};
 use std::panic::PanicInfo;
 use std::path::{Path, PathBuf};
@@ -46,8 +45,7 @@ macro_rules! setup_panic {
     };
 
     panic::set_hook(Box::new(move |info: &PanicInfo| {
-      let file_path = handle_dump(&meta, info)
-        .expect("human-panic: dumping logs to disk failed");
+      let file_path = handle_dump(&meta, info);
 
       print_msg(&file_path, &meta)
         .expect("human-panic: printing error message to console failed");
@@ -57,7 +55,7 @@ macro_rules! setup_panic {
 
 /// Utility function that prints a message to our human users
 pub fn print_msg<P: AsRef<Path>>(
-  file_path: P,
+  file_path: Option<P>,
   meta: &Metadata,
 ) -> IoResult<()> {
   let (_version, name, authors, homepage) =
@@ -79,7 +77,10 @@ pub fn print_msg<P: AsRef<Path>>(
     "We have generated a report file at \"{}\". Submit an \
      issue or email with the subject of \"{} Crash Report\" and include the \
      report as an attachment.\n",
-    file_path.as_ref().display(),
+    match file_path {
+      Some(fp) => format!("{}", fp.as_ref().display()),
+      None => format!("<Failed to store file to disk>"),
+    },
     name
   )?;
 
@@ -102,10 +103,7 @@ pub fn print_msg<P: AsRef<Path>>(
 }
 
 /// Utility function which will handle dumping information to disk
-pub fn handle_dump(
-  meta: &Metadata,
-  panic_info: &PanicInfo,
-) -> Result<PathBuf, FailError> {
+pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo) -> Option<PathBuf> {
   let mut expl = String::new();
 
   let payload = panic_info.payload().downcast_ref::<&str>();
@@ -123,5 +121,12 @@ pub fn handle_dump(
   }
 
   let report = Report::new(&meta.name, &meta.version, Method::Panic, expl);
-  report.persist()
+
+  match report.persist() {
+    Ok(f) => Some(f),
+    Err(_) => {
+      eprintln!("{}", report.serialize().unwrap());
+      None
+    }
+  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub fn print_msg<P: AsRef<Path>>(
      report as an attachment.\n",
     match file_path {
       Some(fp) => format!("{}", fp.as_ref().display()),
-      None => format!("<Failed to store file to disk>"),
+      None => "<Failed to store file to disk>".to_string(),
     },
     name
   )?;

--- a/src/report.rs
+++ b/src/report.rs
@@ -53,6 +53,10 @@ impl Report {
     }
   }
 
+  pub fn serialize(&self) -> Option<String> {
+    toml::to_string_pretty(&self).ok()
+  }
+
   /// Write a file to disk.
   pub fn persist(&self) -> Result<PathBuf, Error> {
     let uuid = Uuid::new_v4().hyphenated().to_string();
@@ -64,7 +68,7 @@ impl Report {
     let file_name = format!("report-{}.toml", &uuid);
     let file_path = Path::new(tmp_dir).join(file_name);
     let mut file = File::create(&file_path)?;
-    let toml = toml::to_string_pretty(&self)?;
+    let toml = self.serialize().unwrap();
     file.write_all(toml.as_bytes())?;
     Ok(file_path)
   }


### PR DESCRIPTION
**Choose one:** 🐛 bug fix

Now when we fail to write the dump to disk, `human-panic` will no longer panic!

## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

Issue: #12 