### PR TITLE
Adding a second endpoint for setup_panic!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,5 @@ nightly = []
 [workspace]
 members = [
   "tests/single-panic",
+  "tests/custom-panic",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,10 @@ pub struct Metadata {
 /// The Metadata struct can't implement `Default` because of orphan rules, which
 /// means you need to provide all fields for initialisation.
 ///
-/// ```rust norun
+/// ```ignore
+/// #[macro_use]
+/// extern crate human_panic;
+/// 
 /// setup_panic!(Metadata {
 ///     name: env!("CARGO_PKG_NAME").into(),
 ///     version: env!("CARGO_PKG_VERSION").into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub struct Metadata {
 /// the values used in your `Cargo.toml` file.
 ///
 /// The Metadata struct can't implement `Default` because of orphan rules, which
-/// means you need to provide all fields for initialisation.Metadata
+/// means you need to provide all fields for initialisation.
 ///
 /// ```rust norun
 /// setup_panic!(Metadata {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,18 +35,19 @@ pub struct Metadata {
 /// as beautiful as your shitty code.
 #[macro_export]
 macro_rules! setup_panic {
-  (meta: Metadata) => {
-    panic::set_hook(Box::new(move |info: &PanicInfo| {
-      let file_path = handle_dump(&meta, info);
-
-      print_msg(file_path, &meta)
-        .expect("human-panic: printing error message to console failed");
-    }));
-  };
-  () => {
+  ($meta:expr) => {
     use human_panic::*;
     use std::panic::{self, PanicInfo};
 
+    panic::set_hook(Box::new(move |info: &PanicInfo| {
+      let file_path = handle_dump(&$meta, info);
+
+      print_msg(file_path, &$meta)
+        .expect("human-panic: printing error message to console failed");
+    }));
+  };
+
+  () => {
     let meta = Metadata {
       version: env!("CARGO_PKG_VERSION").into(),
       name: env!("CARGO_PKG_NAME").into(),
@@ -54,7 +55,7 @@ macro_rules! setup_panic {
       homepage: env!("CARGO_PKG_HOMEPAGE").into(),
     };
 
-    setup_panic!(meta);    
+    setup_panic!(meta);
   };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,14 @@ pub struct Metadata {
 /// as beautiful as your shitty code.
 #[macro_export]
 macro_rules! setup_panic {
+  (meta: Metadata) => {
+    panic::set_hook(Box::new(move |info: &PanicInfo| {
+      let file_path = handle_dump(&meta, info);
+
+      print_msg(file_path, &meta)
+        .expect("human-panic: printing error message to console failed");
+    }));
+  };
   () => {
     use human_panic::*;
     use std::panic::{self, PanicInfo};
@@ -46,13 +54,7 @@ macro_rules! setup_panic {
       homepage: env!("CARGO_PKG_HOMEPAGE").into(),
     };
 
-    panic::set_hook(Box::new(move |info: &PanicInfo| {
-      let file_path = handle_dump(&meta, info)
-        .expect("human-panic: dumping logs to disk failed");
-
-      print_msg(&file_path, &meta)
-        .expect("human-panic: printing error message to console failed");
-    }));
+    setup_panic!(meta);    
   };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,53 @@
+//! Panic handlers for human beings
+//!
+//! [![crates.io version][1]][2] [![build status][3]][4]
+//! [![downloads][5]][6] [![docs.rs docs][7]][8]
+//!
+//! Panic messages for humans. Replacement for
+//! [`std::panic::catch_unwind`](https://doc.rust-lang.org/std/panic/fn.catch_unwind.html)
+//! to make errors nice for humans.
+//!
+//! - [Documentation][8]
+//! - [Crates.io][2]
+//!
+//! ## Why?
+//! When you're building a CLI, polish is super important. Even though Rust is
+//! pretty great at safety, it's not unheard of to access the wrong index in a
+//! vector or have an assert fail somewhere.
+//!
+//! When an error eventually occurs, you probably will want to know about it. So
+//! instead of just providing an error message on the command line, we can create a
+//! call to action for people to submit a report.
+//!
+//! This should empower people to engage in communication, lowering the chances
+//! people might get frustrated. And making it easier to figure out what might be
+//! causing bugs.
+//!
+//! ### Default Output
+//!
+//! ```txt
+//! thread 'main' panicked at 'oops', examples/main.rs:2:3
+//! note: Run with `RUST_BACKTRACE=1` for a backtrace.
+//! ```
+//!
+//! ### Human-Panic Output
+//!
+//! ```txt
+//! Well, this is embarrassing.
+//!
+//! human-panic had a problem and crashed. To help us diagnose the problem you can send us a crash report.
+//!
+//! We have generated a report file at "/var/folders/zw/bpfvmq390lv2c6gn_6byyv0w0000gn/T/report-8351cad6-d2b5-4fe8-accd-1fcbf4538792.toml". Submit an issue or email with the subject of "human-panic Crash Report" and include the report as an attachment.
+//!
+//! - Homepage: https://github.com/yoshuawuyts/human-panic
+//! - Authors: Yoshua Wuyts <yoshuawuyts@gmail.com>
+//!
+//! We take privacy seriously, and do not perform any automated error collection. In order to improve the software, we rely on people to submit reports.
+//!
+//! Thank you kindly!
+
 #![cfg_attr(feature = "nightly", deny(missing_docs))]
 #![cfg_attr(feature = "nightly", feature(external_doc))]
-#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 
 extern crate backtrace;
 #[macro_use]
@@ -30,8 +77,23 @@ pub struct Metadata {
   pub homepage: Cow<'static, str>,
 }
 
-/// Setup the human panic hook that will make all panics
-/// as beautiful as your shitty code.
+/// `human-panic` initialisation macro
+///
+/// You can either call this macro with no arguments `setup_panic!()` or
+/// with a Metadata struct, if you don't want the error message to display
+/// the values used in your `Cargo.toml` file.
+///
+/// The Metadata struct can't implement `Default` because of orphan rules, which
+/// means you need to provide all fields for initialisation.Metadata
+///
+/// ```rust norun
+/// setup_panic!(Metadata {
+///     name: env!("CARGO_PKG_NAME").into(),
+///     version: env!("CARGO_PKG_VERSION").into(),
+///     authors: "My Company Support <support@mycompany.com".into(),
+///     homepage: "support.mycompany.com".into(),
+/// });
+/// ```
 #[macro_export]
 macro_rules! setup_panic {
   ($meta:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Panic messages for humans
 //!
-//! Replacement for 
+//! Replacement for
 //! [`std::panic::catch_unwind`](https://doc.rust-lang.org/std/panic/fn.catch_unwind.html)
 //! to make errors nice for humans.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub struct Metadata {
 /// ```ignore
 /// #[macro_use]
 /// extern crate human_panic;
-/// 
+///
 /// setup_panic!(Metadata {
 ///     name: env!("CARGO_PKG_NAME").into(),
 ///     version: env!("CARGO_PKG_VERSION").into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,8 @@
-//! Panic handlers for human beings
+//! Panic messages for humans
 //!
-//! [![crates.io version][1]][2] [![build status][3]][4]
-//! [![downloads][5]][6] [![docs.rs docs][7]][8]
-//!
-//! Panic messages for humans. Replacement for
+//! Replacement for 
 //! [`std::panic::catch_unwind`](https://doc.rust-lang.org/std/panic/fn.catch_unwind.html)
 //! to make errors nice for humans.
-//!
-//! - [Documentation][8]
-//! - [Crates.io][2]
 //!
 //! ## Why?
 //! When you're building a CLI, polish is super important. Even though Rust is

--- a/tests/custom-panic/Cargo.toml
+++ b/tests/custom-panic/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "custom-panic-test"
+version = "0.1.0"
+authors = ["Human Panic Authors <human-panic-crate@example.com>"]
+
+[dependencies]
+human-panic = { path = "../.." }
+
+[dev-dependencies]
+assert_cli = "0.5.4"

--- a/tests/custom-panic/src/main.rs
+++ b/tests/custom-panic/src/main.rs
@@ -1,0 +1,16 @@
+#[macro_use]
+extern crate human_panic;
+
+use human_panic::Metadata;
+
+fn main() {
+  setup_panic!(Metadata {
+    name: 
+    authors: "My Company Support <support@mycompany.com",
+    homepage: "support.mycompany.com"
+    
+  });
+
+  println!("A normal log message");
+  panic!("OMG EVERYTHING IS ON FIRE!!!");
+}

--- a/tests/custom-panic/tests/integration.rs
+++ b/tests/custom-panic/tests/integration.rs
@@ -6,9 +6,11 @@ fn integration() {
     .stderr()
     .contains("single-panic-test")
     .stderr()
-    .contains("Human Panic Authors")
+    .contains("My Company Support")
     .stderr()
-    .contains("human-panic-crate@example.com")
+    .contains("support@mycompany.com")
+    .stderr()
+    .contains("support.mycompany.com")
     .fails_with(101)
     .unwrap();
 }

--- a/tests/custom-panic/tests/integration.rs
+++ b/tests/custom-panic/tests/integration.rs
@@ -1,0 +1,14 @@
+extern crate assert_cli;
+
+#[test]
+fn integration() {
+  assert_cli::Assert::main_binary()
+    .stderr()
+    .contains("single-panic-test")
+    .stderr()
+    .contains("Human Panic Authors")
+    .stderr()
+    .contains("human-panic-crate@example.com")
+    .fails_with(101)
+    .unwrap();
+}

--- a/tests/custom-panic/tests/integration.rs
+++ b/tests/custom-panic/tests/integration.rs
@@ -4,7 +4,7 @@ extern crate assert_cli;
 fn integration() {
   assert_cli::Assert::main_binary()
     .stderr()
-    .contains("single-panic-test")
+    .contains("custom-panic-test")
     .stderr()
     .contains("My Company Support")
     .stderr()


### PR DESCRIPTION
**Choose one:** This is a 🙋 feature

Adds a second macro end-point for users to use the Metadata struct to provide their own data, overriding the defaults chosen by Cargo.

This depends on #33 

## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
