### PR TITLE
Don't require users to have extern crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub struct Metadata {
 #[macro_export]
 macro_rules! setup_panic {
   ($meta:expr) => {
-    use human_panic::*;
+    use $crate::{handle_dump, print_msg, Metadata};
     use std::panic::{self, PanicInfo};
 
     panic::set_hook(Box::new(move |info: &PanicInfo| {
@@ -106,7 +106,7 @@ macro_rules! setup_panic {
   };
 
   () => {
-    use human_panic::*;
+    use $crate::{handle_dump, print_msg, Metadata};
     use std::panic::{self, PanicInfo};
 
     let meta = Metadata {


### PR DESCRIPTION
By not refering to the name of the crate directly, it us now possible
to re-export and use `setup_panic!` in quicli.

This a somewhat of a 🐛 bug fix, but also a new 🙋 feature.

## Checklist

- [x] tests pass

## Context

I want to use this in quicli

## Semver Changes

Patch version bump is enough.
